### PR TITLE
Fixed - Quota Exceeded - Error

### DIFF
--- a/jquery.storageapi.js
+++ b/jquery.storageapi.js
@@ -281,9 +281,9 @@
 
   // Test if storage is natively available on browser
   function _testStorage(name){
-    if(!window[name]) return false;
     var foo='jsapi';
     try{
+      if(!window[name]) return false;
       window[name].setItem(foo,foo);
       window[name].removeItem(foo);
       return true;


### PR DESCRIPTION
When I ran this on the desktop it worked great but in an HTML5 app on my stock BB10 the _testStorage fired off this error:

QuotaExceededError: Dom exception 22: An attempt was made to add something to storage that exceeded the quota

Not sure how many other devices this happens with, if any, but moving the !window[name] condition within the try solved the issue flawlessly. From my testing this minor change hasn't affected anything else.

Thanks for this project! Works great for what I need it to do.