### PR TITLE
Rare _cookie error

### DIFF
--- a/jquery.storageapi.js
+++ b/jquery.storageapi.js
@@ -242,7 +242,7 @@
     }else{
       o=s;
     }
-    if(o._cookie){
+    if(o && o._cookie){
       // If storage is a cookie, use $.cookie to retrieve keys
       for(var key in $.cookie()){
         if(key!='') {


### PR DESCRIPTION
Trying to get keys() of non existent storage object, like $.localStorage.keys('idontexist'); returns:
>> Uncaught TypeError: Cannot read property '_cookie' of undefined <<
on Chrome (and possibly other browsers).